### PR TITLE
Add Slug to Membership Categories Table

### DIFF
--- a/database/migrations/2024_08_09_070506_add_slug_to_membership_categories.php
+++ b/database/migrations/2024_08_09_070506_add_slug_to_membership_categories.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('membership_categories', function (Blueprint $table) {
+            $table->string('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('membership_categories', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};


### PR DESCRIPTION
Added a slug column to the membership categories table. The problem was that the seed for the table had the slug column specified but the column was non-existent in the database. Because of this, I created a migration to add it.